### PR TITLE
feat: add aria-hidden to sprite sheet

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -136,6 +136,7 @@ export async function createModuleCode(
              svgDom.id = '${options.customDomId}';
              svgDom.setAttribute('xmlns','${XMLNS}');
              svgDom.setAttribute('xmlns:link','${XMLNS_LINK}');
+             svgDom.setAttribute('aria-hidden',true);
            }
            svgDom.innerHTML = ${JSON.stringify(html)};
            ${domInject(options.inject)}


### PR DESCRIPTION
Add `aria-hidden="true"` on the sprite sheet element to hide it from screen readers