### PR TITLE
feat: allow user to directly inject the code into the generated HTML

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -90,6 +90,8 @@ export function createSvgIconsPlugin(opt: ViteSvgIconsPlugin): Plugin {
         const registerId = `/@id/${SVG_ICONS_REGISTER_NAME}`
         const clientId = `/@id/${SVG_ICONS_CLIENT}`
         if ([clientId, registerId].some((item) => url.endsWith(item))) {
+          res.setHeader('Content-Type', 'application/javascript')
+          res.setHeader('Cache-Control', 'no-cache')
           const { code, idSet } = await createModuleCode(
             cache,
             svgoOptions as OptimizeOptions,

--- a/packages/core/src/typing.ts
+++ b/packages/core/src/typing.ts
@@ -1,6 +1,6 @@
 import type { OptimizeOptions } from 'svgo'
 
-export type DomInject = 'body-first' | 'body-last'
+export type DomInject = 'body-first' | 'body-last' | 'index-html'
 
 export interface ViteSvgIconsPlugin {
   /**

--- a/packages/playground/basic/vite.config.ts
+++ b/packages/playground/basic/vite.config.ts
@@ -14,6 +14,7 @@ export default (): UserConfigExport => {
         // icon symbolId
         // default
         symbolId: 'icon-[dir]-[name]',
+        inject: 'index-html',
       }),
     ],
   }


### PR DESCRIPTION
Using `inject: 'index-html'` users of the library can now inline the generated svg-spritesheet as the first child of the `<body>` tag

Closes #106 
Closes #26 