### PR TITLE
feat: Increase build cache to improve build-time performance

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,8 @@ export function createSvgIconsPlugin(opt: ViteSvgIconsPlugin): Plugin {
   const cache = new Map<string, FileStats>()
 
   let isBuild = false
+  let buildCache: Awaited<ReturnType<typeof createModuleCode>> | null = null
+
   const options = {
     svgoOptions: true,
     symbolId: 'icon-[dir]-[name]',
@@ -70,11 +72,15 @@ export function createSvgIconsPlugin(opt: ViteSvgIconsPlugin): Plugin {
         return `export default {}`
       }
 
-      const { code, idSet } = await createModuleCode(
-        cache,
-        svgoOptions as OptimizeOptions,
-        options,
-      )
+      if (!buildCache) {
+        buildCache = await createModuleCode(
+          cache,
+          svgoOptions as OptimizeOptions,
+          options,
+        )
+      }
+
+      const { code, idSet } = buildCache
       if (isRegister) {
         return code
       }


### PR DESCRIPTION
fix #112 

In the case of build and non-ssr, because the plug-in requires the imort virtual module in the root directory, the load function is repeatedly called in the build, and each build generates a full amount of svg files, resulting in a longer build time. Therefore, cache is used to reduce repeated unnecessary builds and reduce the build time